### PR TITLE
Upgrade to clap 4.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
-reqwest = { version = "0.11.14", features = ["blocking"] }
+reqwest = { version = "0.11.14" }
 serde = { version = "1.0.156", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33"
+clap = { version = "4.1.8", features = ["derive"] }
 reqwest = { version = "0.11.14", features = ["blocking"] }
 serde = { version = "1.0.156", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Options:
   -V, --version              Print version
 ```
 
+Try using piping output to `jq` like this:
+
+```bash 
+ $ apiary --api_key=$HONEYCOMB_API_KEY --dataset="<dataset name>" --resource="columns" \
+         | jq --raw-output '.[] | "\(.key_name) \(.id)"';
+
+```

--- a/README.md
+++ b/README.md
@@ -3,3 +3,24 @@
 `apiary` is a command-line interface to the Honeycomb.io API, written in Rust.
 This is the first Rust program I've ever written.
 Constructive criticism is most welcome!
+
+## Usage
+
+Getting help via the `--help` command:
+
+```bash
+$ cargo run -- --help
+    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
+     Running `target/debug/apiary --help`
+A command-line interface to the Honeycomb API
+
+Usage: apiary --api-key <API_KEY> --dataset <DATASET> --resource <RESOURCE>
+
+Options:
+  -a, --api-key <API_KEY>
+  -d, --dataset <DATASET>
+  -r, --resource <RESOURCE>
+  -h, --help                 Print help
+  -V, --version              Print version
+```
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use tokio;
 #[derive(Parser)]
 #[command(name = "apiary")]
 #[command(author = "Blake")]
-#[command(version = "1.0")]
+#[command(version = "0.2.0")]
 #[command(about = "A command-line interface to the Honeycomb API", long_about = None)]
 struct Cli {
     #[arg(short, long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,85 +1,31 @@
-use clap::{Arg, App};
+use clap::Parser;
 use reqwest;
 use tokio;
 
-struct ProgramArgs {
+#[derive(Parser)]
+#[command(name = "apiary")]
+#[command(author = "Blake")]
+#[command(version = "1.0")]
+#[command(about = "A command-line interface to the Honeycomb API", long_about = None)]
+struct Cli {
+    #[arg(short, long)]
     api_key: String,
+    #[arg(short, long)]
     dataset: String,
+    #[arg(short, long)]
     resource: String,
 }
 
-impl ProgramArgs {
-    fn new() -> Self {
-        
-        let about_text = r###"A command-line interface to the Honeycomb API
-
-Try using piping output to `jq` like this:
-
-    apiary --api_key=$HONEYCOMB_API_KEY --dataset="<dataset name>" --resource="columns" \
-        | jq --raw-output '.[] | "\(.key_name) \(.id)"'    
-
-"###;
-
-        // basic app information
-        let app = App::new("apiary")
-            .version("0.1.0")
-            .about(about_text);
-
-        let api_key_option = Arg::with_name("api_key")
-            .long("api_key") // allow --name
-            .short("k") // allow -n
-            .takes_value(true)
-            .help("A valid Honeycomb API key.")
-            .required(true);
-
-        let dataset_option = Arg::with_name("dataset")
-            .long("dataset")
-            .short("d")
-            .takes_value(true)
-            .help("The Honeycomb Dataset to query.")
-            .required(true);
-
-        let resource_option = Arg::with_name("resource")
-            .long("resource")
-            .short("r")
-            .takes_value(true)
-            .help("The Honeycomb Dataset resource to interact with.")
-            .required(true);
-
-        let app = app.arg(api_key_option);
-        let app = app.arg(dataset_option);
-        let app = app.arg(resource_option);
-
-        let matches = app.get_matches();
-
-        let api_key = matches.value_of("api_key")
-            .expect("You must pass in a valid API key with `--api_key`.");
-
-        let dataset = matches.value_of("dataset")
-            .expect("You must pass in a Dataset with `--dataset`.");
-
-        let resource = matches.value_of("resource")
-            .expect("You must pass in a Dataset resource with `--resource`.");
-
-        ProgramArgs { 
-            api_key: api_key.to_string(),
-            dataset: dataset.to_string(),
-            resource: resource.to_string(),
-        }
-    }
-}
-
-
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {
-    let args = ProgramArgs::new();
+    let cli = Cli::parse();
 
-    let url = format!("https://api.honeycomb.io/1/{}/{}", args.resource, args.dataset);
+    let url = format!("https://api.honeycomb.io/1/{}/{}", cli.resource, cli.dataset);
 
     let client = reqwest::Client::new();
     let response = client
         .get(url)
-        .header("x-honeycomb-team", args.api_key)
+        .header("x-honeycomb-team", cli.api_key)
         .send()
         .await
         .expect("failed to get response")


### PR DESCRIPTION
Updating to clap `4.1.8` can save you a bunch of boilerplate code.